### PR TITLE
Use native `<head>`

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,6 @@ export const metadata: Metadata = {
   title: "Remotion and Next.js",
   description: "Remotion and Next.js",
   viewport: "width=device-width, initial-scale=1, maximum-scale=1",
-  icons: [],
 };
 
 export default function RootLayout({
@@ -17,15 +16,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <meta name="description" content="Remotion and Next.js" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, maximum-scale=1"
-        />
-        <link rel="icon" href="/favicon.ico" />
-      </head>
-
       <body>{children}</body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import "../styles/global.css";
-import Head from "next/head";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -18,14 +17,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <Head>
+      <head>
         <meta name="description" content="Remotion and Next.js" />
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
         <link rel="icon" href="/favicon.ico" />
-      </Head>
+      </head>
 
       <body>{children}</body>
     </html>


### PR DESCRIPTION
## What's changed?

1. Fixed this error by using `<head>` instead of `<Head>` from `'next/head'`
```shell
Warning: You're using `next/head` inside the `app` directory, please migrate to the Metadata API. See https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-3-migrating-nexthead for more details.
```