### PR TITLE
[FIX] make-request-route

### DIFF
--- a/lambda/api.ts
+++ b/lambda/api.ts
@@ -54,5 +54,5 @@ export const getProgress = async ({
     bucketName,
   };
 
-  return makeRequest<ProgressResponse>("api/lambda/progress", body);
+  return makeRequest<ProgressResponse>("/api/lambda/progress", body);
 };


### PR DESCRIPTION
In this application, cos its a single-page, this method causes no harm.
But when copied to other application, where the API call is made from a page other than "/", the route is mishandled!

